### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,14 @@ language: php
 
 php:
   - 7.1
+  - 7.2
+  - 7.3
+  - nightly
+
+matrix:
+  allow_failures:
+    - php: nightly
 
 install: composer install
 
-script: phpunit --configuration phpunit.xml --coverage-text --testsuite=Linux
+script: vendor/bin/phpunit --coverage-text --testsuite=Linux

--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,19 @@
     }
   ],
   "require": {
-    "php": ">=5.3.0"
+    "php": ">=7.1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "4.3.*"
+    "phpunit/phpunit": "^7.0"
   },
   "autoload": {
     "psr-4": {
       "Tivie\\OS\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Tivie\\OS\\": "test"
     }
   }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,4 +13,9 @@
             <file>test/DetectorUnixOnWindowsTest.php</file>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/src/Detector.php
+++ b/src/Detector.php
@@ -42,7 +42,7 @@ class Detector implements DetectorInterface
 
     /**
      * OS type constant
-     * @var
+     * @var int
      */
     protected $osConst;
 
@@ -113,7 +113,7 @@ class Detector implements DetectorInterface
         return $this->osConst;
     }
 
-    protected function parsePHPOS($name, $repeat = true)
+    protected function parsePHPOS(string $name, $repeat = true)
     {
         switch ($name) {
 
@@ -249,10 +249,10 @@ class Detector implements DetectorInterface
     /**
      * This method normalizes some names for future compliance
      *
-     * @param $name
+     * @param  string $name
      * @return string
      */
-    protected function normalizePHPOS($name)
+    protected function normalizePHPOS(string $name)
     {
         //Cygwin
         if (stripos($name, 'CYGWIN') !== false) {

--- a/test/DetectorBase.php
+++ b/test/DetectorBase.php
@@ -1,16 +1,16 @@
 <?php
 /**
- * -- php-os-detector -- 
+ * -- php-os-detector --
  * DetectorTest.php created at 18-12-2014
- * 
+ *
  * Copyright 2014 Estevão Soares dos Santos
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,7 +20,9 @@
 
 namespace Tivie\OS;
 
-abstract class DetectorBase extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+abstract class DetectorBase extends TestCase
 {
     /**
      * @var Detector
@@ -39,9 +41,9 @@ abstract class DetectorBase extends \PHPUnit_Framework_TestCase
      */
     public function testGetters()
     {
-        self::assertTrue(is_int($this->os->getFamily()), "getFamily() is not returning an integer (and it should)");
-        self::assertTrue(is_int($this->os->getType()), "getType() is not returning an integer (and it should)");
-        self::assertTrue(is_string($this->os->getKernelName()), "getKernelName() is not returning a string (and it should)");
+        self::assertIsInt($this->os->getFamily(), "getFamily() is not returning an integer (and it should)");
+        self::assertIsInt($this->os->getType(), "getType() is not returning an integer (and it should)");
+        self::assertIsString($this->os->getKernelName(), "getKernelName() is not returning a string (and it should)");
 
         return $this->os;
     }

--- a/test/DetectorLinuxTest.php
+++ b/test/DetectorLinuxTest.php
@@ -1,16 +1,16 @@
 <?php
 /**
- * -- php-os-detector -- 
+ * -- php-os-detector --
  * DetectorLinuxTest.php created at 18-12-2014
- * 
+ *
  * Copyright 2014 Estevão Soares dos Santos
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,8 +19,6 @@
  **/
 
 namespace Tivie\OS;
-
-require_once('DetectorBase.php');
 
 class DetectorLinuxTest extends DetectorBase
 {
@@ -42,6 +40,9 @@ class DetectorLinuxTest extends DetectorBase
         self::assertEquals(UNIX_FAMILY, $this->os->getFamily());
         self::assertEquals(LINUX, $this->os->getType());
         self::assertEquals('LINUX', strtoupper($this->os->getKernelName()));
+        self::assertTrue($this->os->isUnixLike());
+        self::assertFalse($this->os->isOSX());
+        self::assertFalse($this->os->isWindowsLike());
     }
 
 }

--- a/test/DetectorUnixOnWindowsTest.php
+++ b/test/DetectorUnixOnWindowsTest.php
@@ -21,8 +21,6 @@
 
 namespace Tivie\OS;
 
-require_once('DetectorBase.php');
-
 class DetectorUnixOnWindowsTest extends DetectorBase
 {
     /**

--- a/test/DetectorUnixTest.php
+++ b/test/DetectorUnixTest.php
@@ -1,16 +1,16 @@
 <?php
 /**
- * -- php-os-detector -- 
+ * -- php-os-detector --
  * DetectorUnixTest.php created at 18-12-2014
- * 
+ *
  * Copyright 2014 Estevão Soares dos Santos
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,8 +19,6 @@
  **/
 
 namespace Tivie\OS;
-
-require_once('DetectorBase.php');
 
 class DetectorUnixTest extends DetectorBase
 {

--- a/test/DetectorWindowsTest.php
+++ b/test/DetectorWindowsTest.php
@@ -20,8 +20,6 @@
 
 namespace Tivie\OS;
 
-require_once('DetectorBase.php');
-
 class DetectorWindowsTest extends DetectorBase
 {
 


### PR DESCRIPTION
# Changed log
- Add `php-7.1` to `php-7.3` tests in Travis CI build.
- Let this package require `php-7.1` version at least.
- Using the latest stable PHPUnit version.
- Add the `filter` tag to let PHPUnit can do the code coverage work.
- Add the missed type hint in some method annotations.
- Remove `require_once('DetectorBase.php');` because of useless. The `vendor/autoload.php` will load these classes in `tests` folder automatically.
- Add the missed type hint for some method annotations.